### PR TITLE
Add 'var' to deriv call

### DIFF
--- a/chapter2/2.56.scm
+++ b/chapter2/2.56.scm
@@ -18,7 +18,7 @@
              (make-exponentiation 
                (base exp) 
                (- (exponent exp) 1))
-             (deriv (base exp)))))
+             (deriv (base exp) var))))
         (else
          (error "unknown expression type -- DERIV" exp))))
 


### PR DESCRIPTION
The deriv call dealing with exponentiation was missing its second parameter (var).